### PR TITLE
Fixed #41

### DIFF
--- a/SamplesCommon/SamplesCommon/ImageLoader/ImageLoader.cs
+++ b/SamplesCommon/SamplesCommon/ImageLoader/ImageLoader.cs
@@ -214,7 +214,8 @@ namespace SamplesCommon.ImageLoader
 
         public async Task DrawSurface(CompositionDrawingSurface surface, Uri uri, Size size)
         {
-            using (var canvasBitmap = await CanvasBitmap.LoadAsync(_canvasDevice, uri))
+            var canvasDevice = CanvasComposition.GetCanvasDevice(_graphicsDevice);
+            using (var canvasBitmap = await CanvasBitmap.LoadAsync(canvasDevice, uri))
             {
                 var bitmapSize = canvasBitmap.Size;
 


### PR DESCRIPTION
DrawSurface now retrieves the CanvasDevice from the CompositionGraphicsDevice since it may not be cached locally.