### PR TITLE
Fixes regarding ImageLoader and added CircleSurface

### DIFF
--- a/SampleGallery/Samples/SDK 10586/PropertySets/PropertySets.xaml.cs
+++ b/SampleGallery/Samples/SDK 10586/PropertySets/PropertySets.xaml.cs
@@ -39,7 +39,7 @@ namespace CompositionSampleGallery
         private void SamplePage_Loaded(object sender, Windows.UI.Xaml.RoutedEventArgs e)
         {
             Compositor compositor = ElementCompositionPreview.GetElementVisual(MyGrid).Compositor;
-            IImageLoader imageLoader = ImageLoaderFactory.CreateImageLoader(compositor);
+            _imageLoader = ImageLoaderFactory.CreateImageLoader(compositor);
             ContainerVisual container = compositor.CreateContainerVisual();
             ElementCompositionPreview.SetElementChildVisual(MyGrid, container);
 
@@ -49,11 +49,11 @@ namespace CompositionSampleGallery
             //
 
             CompositionSurfaceBrush redBrush = compositor.CreateSurfaceBrush();
-            _redBallSurface = imageLoader.CreateManagedSurfaceFromUri(new Uri("ms-appx:///Samples/SDK 10586/PropertySets/RedBall.png"));
+            _redBallSurface = _imageLoader.CreateManagedSurfaceFromUri(new Uri("ms-appx:///Samples/SDK 10586/PropertySets/RedBall.png"));
             redBrush.Surface = _redBallSurface.Surface;
 
             CompositionSurfaceBrush blueBrush = compositor.CreateSurfaceBrush();
-            _blueBallSurface = imageLoader.CreateManagedSurfaceFromUri(new Uri("ms-appx:///Samples/SDK 10586/PropertySets/BlueBall.png"));
+            _blueBallSurface = _imageLoader.CreateManagedSurfaceFromUri(new Uri("ms-appx:///Samples/SDK 10586/PropertySets/BlueBall.png"));
             blueBrush.Surface = _blueBallSurface.Surface;
 
 
@@ -124,8 +124,10 @@ namespace CompositionSampleGallery
         {
             _redBallSurface.Dispose();
             _blueBallSurface.Dispose();
+            _imageLoader.Dispose();
         }
 
+        private IImageLoader _imageLoader;
         private IManagedSurface _redBallSurface;
         private IManagedSurface _blueBallSurface;
     }

--- a/SampleGallery/Samples/SDK 10586/TransitionAnimation-ColorBloom/ColorBloomTransition.xaml.cs
+++ b/SampleGallery/Samples/SDK 10586/TransitionAnimation-ColorBloom/ColorBloomTransition.xaml.cs
@@ -166,7 +166,7 @@ namespace CompositionSampleGallery
         /// </summary>
         private void ColorBloomTransition_Unloaded(object sender, RoutedEventArgs e)
         {
-            transition.DisposeSurfaces();
+            transition.Dispose();
         }
 
         #endregion

--- a/SampleGallery/Samples/SDK 10586/TransitionAnimation-ColorBloom/ColorBloomTransitionHelper.cs
+++ b/SampleGallery/Samples/SDK 10586/TransitionAnimation-ColorBloom/ColorBloomTransitionHelper.cs
@@ -19,6 +19,7 @@ using System;
 using System.Linq;
 using System.Numerics;
 using Windows.Foundation;
+using Windows.UI;
 using Windows.UI.Composition;
 using Windows.UI.Xaml;
 using Windows.UI.Xaml.Hosting;
@@ -28,7 +29,7 @@ namespace CompositionSampleGallery
     /// <summary>
     /// A helper class encapsulating the function and visuals for a Color Bloom transition animation.
     /// </summary>
-    public class ColorBloomTransitionHelper
+    public class ColorBloomTransitionHelper : IDisposable
     {
         #region Member variables
 
@@ -37,7 +38,7 @@ namespace CompositionSampleGallery
         ContainerVisual _containerForVisuals;
         ScalarKeyFrameAnimation _bloomAnimation;
         IImageLoader _imageLoader;
-        IManagedSurface _circleMaskSurface;
+        ICircleSurface _circleMaskSurface;
 
         #endregion
 
@@ -63,7 +64,7 @@ namespace CompositionSampleGallery
 
             // initialize the ImageLoader and create the circle mask
             _imageLoader = ImageLoaderFactory.CreateImageLoader(_compositor);
-            _circleMaskSurface = _imageLoader.CreateManagedSurfaceFromUri(new Uri("ms-appx:///Samples/SDK 10586/TransitionAnimation-ColorBloom/CircleOpacityMask.png"));
+            _circleMaskSurface = _imageLoader.CreateCircleSurface(200, Colors.White);
         }
         #endregion
 
@@ -102,9 +103,10 @@ namespace CompositionSampleGallery
         /// <summary>
         /// Cleans up any remaining surfaces.
         /// </summary>
-        public void DisposeSurfaces()
+        public void Dispose()
         {
             _circleMaskSurface.Dispose();
+            _imageLoader.Dispose();
         }
 
         #endregion

--- a/SampleGallery/Samples/SDK 10586/Z-Order Scrolling/Z-OrderScrolling.xaml.cs
+++ b/SampleGallery/Samples/SDK 10586/Z-Order Scrolling/Z-OrderScrolling.xaml.cs
@@ -22,6 +22,7 @@ using System.Numerics;
 using System.Threading.Tasks;
 using Windows.Foundation;
 using Windows.Graphics.DirectX;
+using Windows.UI;
 using Windows.UI.Composition;
 using Windows.UI.Xaml;
 using Windows.UI.Xaml.Controls;
@@ -78,6 +79,7 @@ namespace CompositionSampleGallery
         {
             _profilePictureSurface.Dispose();
             _circleMaskSurface.Dispose();
+            _imageLoader.Dispose();
         }
 
         /// <summary>
@@ -352,7 +354,7 @@ namespace CompositionSampleGallery
             // Load in the circular mask picture asx a brush using the composition Toolkit.
             //
             CompositionSurfaceBrush maskBrush = _compositor.CreateSurfaceBrush();
-            _circleMaskSurface = _imageLoader.CreateManagedSurfaceFromUri(new Uri("ms-appx:///Assets/CircleMask.png"));
+            _circleMaskSurface = _imageLoader.CreateCircleSurface(200, Colors.White);
             maskBrush.Surface = _circleMaskSurface.Surface;
             brush.SetSourceParameter("mask", maskBrush);
 
@@ -436,7 +438,7 @@ namespace CompositionSampleGallery
         private ExpressionAnimation _profileContentTranslationAnimation;
         private ExpressionAnimation _profileContentScaleAnimation;
 
-        private IManagedSurface _circleMaskSurface;
+        private ICircleSurface _circleMaskSurface;
         private IManagedSurface _profilePictureSurface;
 
         private float _initialScaleAmount = .8f;

--- a/SampleGallery/Samples/SDK 14393/ImplicitAnimationTransformer/ImplicitAnimationTransformer.xaml
+++ b/SampleGallery/Samples/SDK 14393/ImplicitAnimationTransformer/ImplicitAnimationTransformer.xaml
@@ -5,6 +5,7 @@
     xmlns:local="using:CompositionSampleGallery"
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    Unloaded="ImplicitAnimationTransformer_Unloaded"
     mc:Ignorable="d">
 
     <Grid Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">

--- a/SampleGallery/Samples/SDK 14393/ImplicitAnimationTransformer/ImplicitAnimationTransformer.xaml.cs
+++ b/SampleGallery/Samples/SDK 14393/ImplicitAnimationTransformer/ImplicitAnimationTransformer.xaml.cs
@@ -47,6 +47,8 @@ namespace CompositionSampleGallery
         // Windows.UI.Composition
         private Compositor _compositor;
         private ContainerVisual _root;
+        private List<CompositionSurfaceBrush> _imageBrushList;
+        private IImageLoader _imageLoader;
 
         // Constants
         private const float _posX = 600;
@@ -96,12 +98,12 @@ namespace CompositionSampleGallery
 
             //Create a list of image brushes that can be applied to a visual
             string[] imageNames = { "60Banana.png", "60Lemon.png", "60Vanilla.png", "60Mint.png", "60Orange.png", "110Strawberry.png", "60SprinklesRainbow.png" };
-            List<CompositionSurfaceBrush> imageBrushList = new List<CompositionSurfaceBrush>();
-            IImageLoader imageFactory = ImageLoaderFactory.CreateImageLoader(_compositor);
+            _imageBrushList = new List<CompositionSurfaceBrush>();
+            _imageLoader = ImageLoaderFactory.CreateImageLoader(_compositor);
             for (int k = 0; k < imageNames.Length; k++)
             {
-                var surface = imageFactory.LoadImageFromUri(new Uri("ms-appx:///Samples/SDK 14393/ImplicitAnimationTransformer/" + imageNames[k]));
-                imageBrushList.Add(_compositor.CreateSurfaceBrush(surface));
+                var surface = _imageLoader.LoadImageFromUri(new Uri("ms-appx:///Samples/SDK 14393/ImplicitAnimationTransformer/" + imageNames[k]));
+                _imageBrushList.Add(_compositor.CreateSurfaceBrush(surface));
             }
 
             // Create nxn matrix of visuals where n=row/ColumnCount-1 and passes random image brush to the function
@@ -111,7 +113,7 @@ namespace CompositionSampleGallery
                 posXUpdated = i * _distance;
                 for (int j = 1; j < _columnCount; j++)
                 {
-                    CompositionSurfaceBrush brush = imageBrushList[randomBrush.Next(imageBrushList.Count)];
+                    CompositionSurfaceBrush brush = _imageBrushList[randomBrush.Next(_imageBrushList.Count)];
 
                     posYUpdated = j * _distance;
                     _root.Children.InsertAtTop(CreateChildElement(brush, posXUpdated, posYUpdated));
@@ -371,6 +373,15 @@ namespace CompositionSampleGallery
                     child.ImplicitAnimations = null;
                 }
             }
+        }
+
+        private void ImplicitAnimationTransformer_Unloaded(object sender, RoutedEventArgs e)
+        {
+            foreach(var brush in _imageBrushList)
+            {
+                brush.Dispose();
+            }
+            _imageLoader.Dispose();
         }
     }
 }

--- a/SampleGallery/Samples/SDK 14393/Interactions3D/Interactions3D.cs
+++ b/SampleGallery/Samples/SDK 14393/Interactions3D/Interactions3D.cs
@@ -71,6 +71,12 @@ namespace CompositionSampleGallery
 
             _scaleTracker.Dispose();
             _scaleTracker = null;
+
+            foreach(var brush in _imageBrushes)
+            {
+                brush.Dispose();
+            }
+            _imageLoader.Dispose();
         }
 
 

--- a/SampleGallery/Samples/SDK 14393/LayerVisual/LayerVisualAnd3DTransform.xaml
+++ b/SampleGallery/Samples/SDK 14393/LayerVisual/LayerVisualAnd3DTransform.xaml
@@ -6,7 +6,9 @@
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     mc:Ignorable="d"
-    Loaded="Page_Loaded" SizeChanged="SamplePage_SizeChanged">
+    Loaded="Page_Loaded" 
+    Unloaded="SamplePage_Unloaded"
+    SizeChanged="SamplePage_SizeChanged">
 
     <Grid x:Name="RoomGrid" Width="612" Height="600" VerticalAlignment="Top" HorizontalAlignment="Left">
         <Grid.ColumnDefinitions>

--- a/SampleGallery/Samples/SDK 14393/LayerVisual/LayerVisualAnd3DTransform.xaml.cs
+++ b/SampleGallery/Samples/SDK 14393/LayerVisual/LayerVisualAnd3DTransform.xaml.cs
@@ -556,6 +556,15 @@ namespace CompositionSampleGallery
             }
         }
 
+        private void SamplePage_Unloaded(object sender, Windows.UI.Xaml.RoutedEventArgs e)
+        {
+            foreach(var brush in _imageSurfaces)
+            {
+                brush.Dispose();
+            }
+            _imageLoader.Dispose();
+        }
+
         private const int _fColumnCount = 3;
         private Compositor _compositor;
         private Visual _roomVisual;

--- a/SampleGallery/Samples/SDK 14393/ShadowPlayground/ShadowPlayground.xaml.cs
+++ b/SampleGallery/Samples/SDK 14393/ShadowPlayground/ShadowPlayground.xaml.cs
@@ -30,7 +30,7 @@ namespace CompositionSampleGallery
         private SpriteVisual _imageVisual;
         private CompositionImage _image;
         private IImageLoader _imageLoader;
-        private IManagedSurface _imageMaskSurface;
+        private ICircleSurface _imageMaskSurface;
         private CompositionMaskBrush _maskBrush;
         private bool _isMaskEnabled;
 
@@ -56,7 +56,7 @@ namespace CompositionSampleGallery
 
             // Load mask asset onto surface using helpers in SamplesCommon
             _imageLoader = ImageLoaderFactory.CreateImageLoader(_compositor);
-            _imageMaskSurface = _imageLoader.CreateManagedSurfaceFromUri(new Uri("ms-appx:///Assets/CircleMask.png"));
+            _imageMaskSurface = _imageLoader.CreateCircleSurface(200, Colors.White);
 
             // Create surface brush for mask
             CompositionSurfaceBrush mask = _compositor.CreateSurfaceBrush();

--- a/SampleGallery/Samples/SDK 14393/VideoPlayground/VideoPlaygroundViewModel.cs
+++ b/SampleGallery/Samples/SDK 14393/VideoPlayground/VideoPlaygroundViewModel.cs
@@ -20,6 +20,7 @@ using Windows.UI.Xaml;
 using Windows.UI.Xaml.Controls;
 using Windows.UI.Xaml.Hosting;
 using SamplesCommon.ImageLoader;
+using Windows.UI;
 
 namespace CompositionSampleGallery
 {
@@ -52,7 +53,6 @@ namespace CompositionSampleGallery
     {
         #region Statics
         private static readonly int MaxNumberOfLights = 2;
-        private static readonly string CircleImagePath = "ms-appx:///Assets/CircleMask.png";
         #endregion
 
         #region Private Members
@@ -69,7 +69,7 @@ namespace CompositionSampleGallery
         // Composition - Lighting
         private LightMode _lightMode;
         private List<Light> _lights;
-        private IManagedSurface _circleSurface;
+        private ICircleSurface _circleSurface;
         private CompositionSurfaceBrush _circleBrush;
 
         // Page specific objects/variables.
@@ -649,7 +649,7 @@ namespace CompositionSampleGallery
             if (_circleBrush == null)
             {
                 _imageLoader = ImageLoaderFactory.CreateImageLoader(_compositor);
-                _circleSurface = _imageLoader.CreateManagedSurfaceFromUri(new Uri(CircleImagePath));
+                _circleSurface = _imageLoader.CreateCircleSurface(200, Colors.White);
                 _circleBrush = _compositor.CreateSurfaceBrush(_circleSurface.Surface);
             }
         }

--- a/SamplesCommon/SamplesCommon/ImageLoader/CircleSurface.cs
+++ b/SamplesCommon/SamplesCommon/ImageLoader/CircleSurface.cs
@@ -1,0 +1,97 @@
+﻿using Microsoft.Graphics.Canvas.UI.Composition;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Numerics;
+using System.Text;
+using System.Threading.Tasks;
+using Windows.Foundation;
+using Windows.UI;
+using Windows.UI.Composition;
+
+namespace SamplesCommon.ImageLoader
+{
+    public interface ICircleSurface : IDisposable
+    {
+        IImageLoader ImageLoader { get; }
+        ICompositionSurface Surface { get; }
+        float Radius { get; set; }
+        Color Color { get; set; }
+        Size Size { get; }
+        void RedrawSurface();
+    }
+
+    class CircleSurface : ICircleSurface
+    {
+        private IImageLoaderInternal _imageLoader;
+        private CompositionDrawingSurface _surface;
+        private float _radius;
+        private Color _color;
+
+        public IImageLoader ImageLoader { get { return _imageLoader; } }
+        public ICompositionSurface Surface { get { return _surface; } }
+        public Size Size { get { return _surface.Size; } }
+        
+        public float Radius
+        {
+            get { return _radius; }
+            set
+            {
+                if (_radius != value)
+                {
+                    _radius = value;
+                    _imageLoader.ResizeSurface(_surface, new Size(_radius * 2, _radius * 2));
+                    RedrawSurface();
+                }
+            }
+        }
+
+        public Color Color
+        {
+            get { return _color; }
+            set
+            {
+                if (_color != value)
+                {
+                    _color = value;
+                    RedrawSurface();
+                }
+            }
+        }
+
+        public CircleSurface(IImageLoaderInternal imageLoader, float radius, Color color)
+        {
+            _imageLoader = imageLoader;
+            _radius = radius;
+            _color = color;
+            _surface = _imageLoader.CreateSurface(new Size(radius * 2, radius * 2));
+
+            _imageLoader.DeviceReplacedEvent += OnDeviceReplaced;
+        }
+
+        private void OnDeviceReplaced(object sender, object e)
+        {
+            RedrawSurface();
+        }
+
+        public void RedrawSurface()
+        {
+            _imageLoader.DrawIntoSurface(_surface, (surface, device) =>
+            {
+                using (var session = CanvasComposition.CreateDrawingSession(surface))
+                {
+                    session.Clear(Colors.Transparent);
+                    session.FillCircle(new Vector2(_radius, _radius), _radius, _color);
+                }
+            });
+        }
+
+        public void Dispose()
+        {
+            _surface.Dispose();
+            _imageLoader.DeviceReplacedEvent -= OnDeviceReplaced;
+            _surface = null;
+            _imageLoader = null;
+        }
+    }
+}

--- a/SamplesCommon/SamplesCommon/SamplesCommon.csproj
+++ b/SamplesCommon/SamplesCommon/SamplesCommon.csproj
@@ -115,6 +115,7 @@
     <Compile Include="ColorMixer.xaml.cs">
       <DependentUpon>ColorMixer.xaml</DependentUpon>
     </Compile>
+    <Compile Include="ImageLoader\CircleSurface.cs" />
     <Compile Include="PennerEquationBuilder.cs" />
     <Compile Include="PerspectivePanel.cs" />
     <Compile Include="CompositionImage.cs" />


### PR DESCRIPTION
ImageLoader creates a new device instead of using the shared device, which will now dispose properly. Fixed samples that weren't disposing the ImageLoader. CircleSurface was added as well.