### PR TITLE
Fix header and spacing in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,68 @@
-# Windows UI Dev LabsWelcome to the Windows UI Dev Labs repository for the latest code samples, demos, and developer feedback for building beautiful and engaging Universal Windows Platform apps using Windows UI.The code samples and demos are targeted for developers who are interested in experimenting, building, and providing feedback on the latest flighting Windows UI APIs. We are focused on creating a place where we can experiment, inpsire, and receive developer feedback on:- Flighting APIs for Windows UI- Testing out new UX patterns- Early reference implementations and prototypes- Inspiring demonstrations of the Windows UI API  If you are a developer getting familiar with the [Windows.UI.Xaml](https://msdn.microsoft.com/en-us/library/windows/apps/windows.ui.xaml.aspx) and [Windows.UI.Composition](https://msdn.microsoft.com/en-us/library/windows/apps/windows.ui.composition.aspx) APIs, want to build beautiful UI experiences, and don't mind a few bugs here and there; then, this is the place for you. We also want to see what inspiring UX you're building and you can reach out to us on Twitter [@WindowsUI](https://twitter.com/windowsui).We're excited to see what you can you make with Windows UI.## Project StructureThe following outlines the key folders for the project.### DemosThe Demos folder contains standalone code demos that are focused on combining many concepts and feature sets in the Windows UI space to demonstrate interesting user experience. The code is to help inspire and prototype novel and engaging user experiences.### Sample GalleryThe Sample Gallery is an application itself that contains code examples of flighting various Windows UI APIs. The Sample Gallery uses conditional compilation to only compile the code samples that are available in your target SDK.By default the Sample Gallery is set to the last major platform release, however, you can retarget the Sample Gallery project file to the latest SDK that you have installed to see more samples light up.### Samples CommonThese are early reference implementations, prototypes, and utilties the team has built over the course of developing our demos and code examples. These are code examples of common code that's shared across code samples and demos.### ExpressionBuilderA set of C# classes enabling developers to build ExpressionAnimations in a more type-safe environment.### Samples NativeA native library used to access some lower level functionality that has no WinRT projections.## Developing and Building with Windows UIThese samples require Visual Studio 2017 and the Windows Software Development Kit (SDK) for Windows 10 to build, test, and deploy your Universal Windows apps. [Get a free copy of Visual Studio 2017 Community Edition with support for building Universal Windows apps](http://go.microsoft.com/fwlink/?LinkID=280676)Additionally, to stay on top of the latest updates to Windows and the development tools, become a Windows Insider by joining the Windows Insider Program.[Become a Windows Insider](https://insider.windows.com/)We will be frequently iterating and updating code samples in this repository, so it's recommended you become an Insider, follow us on Twitter for the latest updates, and provide feedback in the Issue section. ##Learning More about Windows UI APIsWant to learn about all the exciting features that the Windows UI APIs can bring to your app? Check out the BUILD 2016 session recordings for Windows UI.[List of talks for BUILD 2016 that can be watched on Channel9](https://github.com/Microsoft/WindowsUIDevLabs/wiki/Windows-UI-Newsletter---Volume-1#build-sessions)There are also a number of blogs and blog posts from members of our community that go into the specifics of using the Windows.UI.Composition APIs. A few of them are listed below.- Kenny Kerr has [a detailed introduction to graphics and animation using the Windows Composition APIs](https://msdn.microsoft.com/en-us/magazine/mt590968) in MSDN magazine- Mike Taulty has [a number of blog posts](https://mtaulty.com/category/composition/) experimenting with the Windows.UI.Composition APIs, with topics relating to effects and performance.- Microsoft Windows UI team member Robert Mikhayelyan talks about UWP development and the basics of the Composition APIs in [his personal blog](http://blog.robmikh.com/).- XAML Brewer Diederik Krols has many [in-depth posts on Effects and custom Windows UI controls](https://xamlbrewer.wordpress.com/category/composition-api/).This project has adopted the [Microsoft Open Source Code of Conduct](https://opensource.microsoft.com/codeofconduct/). For more information see the [Code of Conduct FAQ](https://opensource.microsoft.com/codeofconduct/faq/) or contact [opencode@microsoft.com](mailto:opencode@microsoft.com) with any additional questions or comments.
+# Windows UI Dev Labs
+
+Welcome to the Windows UI Dev Labs repository for the latest code samples, demos, and developer feedback for building beautiful and engaging Universal Windows Platform apps using Windows UI.
+
+The code samples and demos are targeted for developers who are interested in experimenting, building, and providing feedback on the latest flighting Windows UI APIs. 
+
+We are focused on creating a place where we can experiment, inpsire, and receive developer feedback on:
+- Flighting APIs for Windows UI
+- Testing out new UX patterns
+- Early reference implementations and prototypes
+- Inspiring demonstrations of the Windows UI API  
+
+If you are a developer getting familiar with the [Windows.UI.Xaml](https://msdn.microsoft.com/en-us/library/windows/apps/windows.ui.xaml.aspx) and [Windows.UI.Composition](https://msdn.microsoft.com/en-us/library/windows/apps/windows.ui.composition.aspx) APIs, want to build beautiful UI experiences, and don't mind a few bugs here and there; then, this is the place for you. 
+
+We also want to see what inspiring UX you're building and you can reach out to us on Twitter [@WindowsUI](https://twitter.com/windowsui).
+
+We're excited to see what you can you make with Windows UI.
+
+## Project Structure
+
+The following outlines the key folders for the project.
+
+### Demos
+
+The Demos folder contains standalone code demos that are focused on combining many concepts and feature sets in the Windows UI space to demonstrate interesting user experience. The code is to help inspire and prototype novel and engaging user experiences.
+
+### Sample Gallery
+
+The Sample Gallery is an application itself that contains code examples of flighting various Windows UI APIs. The Sample Gallery uses conditional compilation to only compile the code samples that are available in your target SDK.
+
+By default the Sample Gallery is set to the last major platform release, however, you can retarget the Sample Gallery project file to the latest SDK that you have installed to see more samples light up.
+
+### Samples Common
+These are early reference implementations, prototypes, and utilties the team has built over the course of developing our demos and code examples. These are code examples of common code that's shared across code samples and demos.
+
+### ExpressionBuilder
+
+A set of C# classes enabling developers to build ExpressionAnimations in a more type-safe environment.
+
+### Samples Native
+
+A native library used to access some lower level functionality that has no WinRT projections.
+
+## Developing and Building with Windows UI
+
+These samples require Visual Studio 2017 and the Windows Software Development Kit (SDK) for Windows 10 to build, test, and deploy your Universal Windows apps. 
+
+[Get a free copy of Visual Studio 2017 Community Edition with support for building Universal Windows apps](http://go.microsoft.com/fwlink/?LinkID=280676)
+
+Additionally, to stay on top of the latest updates to Windows and the development tools, become a Windows Insider by joining the Windows Insider Program.
+
+[Become a Windows Insider](https://insider.windows.com/)
+
+We will be frequently iterating and updating code samples in this repository, so it's recommended you become an Insider, follow us on Twitter for the latest updates, and provide feedback in the Issue section. 
+
+## Learning More about Windows UI APIs
+
+Want to learn about all the exciting features that the Windows UI APIs can bring to your app? Check out the BUILD 2016 session recordings for Windows UI.
+
+[List of talks for BUILD 2016 that can be watched on Channel9](https://github.com/Microsoft/WindowsUIDevLabs/wiki/Windows-UI-Newsletter---Volume-1#build-sessions)
+
+There are also a number of blogs and blog posts from members of our community that go into the specifics of using the Windows.UI.Composition APIs. A few of them are listed below.
+- Kenny Kerr has [a detailed introduction to graphics and animation using the Windows Composition APIs](https://msdn.microsoft.com/en-us/magazine/mt590968) in MSDN magazine
+- Mike Taulty has [a number of blog posts](https://mtaulty.com/category/composition/) experimenting with the Windows.UI.Composition APIs, with topics relating to effects and performance.
+- Microsoft Windows UI team member Robert Mikhayelyan talks about UWP development and the basics of the Composition APIs in [his personal blog](http://blog.robmikh.com/).
+- XAML Brewer Diederik Krols has many [in-depth posts on Effects and custom Windows UI controls](https://xamlbrewer.wordpress.com/category/composition-api/).
+
+This project has adopted the [Microsoft Open Source Code of Conduct](https://opensource.microsoft.com/codeofconduct/). For more information see the [Code of Conduct FAQ](https://opensource.microsoft.com/codeofconduct/faq/) or contact [opencode@microsoft.com](mailto:opencode@microsoft.com) with any additional questions or comments.


### PR DESCRIPTION
GitHub has changed its markdown parser to commonmark. This broke one of the headers and I have fixed that in this PR.