### PR TITLE
Fix InvalidCastException in Animation_Batches 

### DIFF
--- a/Demos/Reference Demos/Animation_Batches/Animation_Batches/MainPage.xaml.cs
+++ b/Demos/Reference Demos/Animation_Batches/Animation_Batches/MainPage.xaml.cs
@@ -56,7 +56,7 @@ namespace Animation_Batches
         {
             // Intialize the Compositor
             _compositor = new Compositor();
-            _root = (ContainerVisual)ElementCompositionPreview.GetElementVisual(Container);
+            _root = ElementCompositionPreview.GetElementVisual(Container);
             _compositor = _root.Compositor;
 
             _linear = _compositor.CreateLinearEasingFunction();


### PR DESCRIPTION
Addresses the Animation_Batches crash from issue #208 

It seems to be fixed (and the sample overall seems to then work fine) by just removing the "(ContainerVisual)" cast. 

I'm a little unsure about submitting this change because I don't really understand the context (how did it get this way to begin with? did it work on an older version of the API?) but here's a PR anyway.